### PR TITLE
Wrapped nodes retains position of first node in list

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ the selected elements using the following jQuery-like manipulation functions:
 -   `replaceAll()`, `replaceWith()`
 -   `text()`
 -   `unwrap()`
+-   `unwrapInner()`
 -   `wrap()`, `wrapInner()`, `wrapAll()`
 
 To get the modified DOM as HTML code use `html()` (returns innerHTML of the first node in your crawler object)

--- a/Tests/HtmlPageCrawlerTest.php
+++ b/Tests/HtmlPageCrawlerTest.php
@@ -321,9 +321,9 @@ class HtmlPageCrawlerTest extends \PHPUnit_Framework_TestCase
      */
     public function testWrapAll()
     {
-        $c = HtmlPageCrawler::create('<div id="content"><p>Absatz 1</p><p>Absatz 2</p><p>Absatz 3</p></div>');
+        $c = HtmlPageCrawler::create('<div id="content"><div>Before</div><p>Absatz 1</p><div>Inner</div><p>Absatz 2</p><p>Absatz 3</p><div>After</div></div>');
         $c->filter('p')->wrapAll('<div class="a">');
-        $this->assertEquals('<div id="content"><div class="a"><p>Absatz 1</p><p>Absatz 2</p><p>Absatz 3</p></div></div>', $c->saveHTML());
+        $this->assertEquals('<div id="content"><div>Before</div><div class="a"><p>Absatz 1</p><p>Absatz 2</p><p>Absatz 3</p></div><div>Inner</div><div>After</div></div>', $c->saveHTML());
 
         // Test for wrapping with elements that have children
         $c = HtmlPageCrawler::create('<div id="content"><p>Absatz 1</p><p>Absatz 2</p><p>Absatz 3</p></div>');
@@ -346,10 +346,21 @@ class HtmlPageCrawlerTest extends \PHPUnit_Framework_TestCase
      */
     public function testUnwrap()
     {
-        $c = HtmlPageCrawler::create('<div id="content"><div class="a"><p>Absatz 1</p></div></div>');
+        $c = HtmlPageCrawler::create('<div id="content"><div>Before</div><div class="a"><p>Absatz 1</p></div><div>After</div></div>');
         $p = $c->filter('p');
         $p->unwrap();
-        $this->assertEquals('<div id="content"><p>Absatz 1</p></div>', $c->saveHTML());
+        $this->assertEquals('<div id="content"><div>Before</div><p>Absatz 1</p><div>After</div></div>', $c->saveHTML());
+    }
+
+    /**
+     * @covers Wa72\HtmlPageDom\HtmlPageCrawler::unwrapInner
+     */
+    public function testUnwrapInner()
+    {
+        $c = HtmlPageCrawler::create('<div id="content"><div>Before</div><div class="a"><p>Absatz 1</p></div><div>After</div></div>');
+        $p = $c->filter('div.a');
+        $p->unwrapInner();
+        $this->assertEquals('<div id="content"><div>Before</div><p>Absatz 1</p><div>After</div></div>', $c->saveHTML());
     }
 
     /**

--- a/src/HtmlPageCrawler.php
+++ b/src/HtmlPageCrawler.php
@@ -727,14 +727,38 @@ class HtmlPageCrawler extends Crawler
      */
     public function unwrap()
     {
-        foreach ($this as $i => $node) {
-            /** @var \DOMNode $node */
-            if ($parent = $node->parentNode) {
-                $parent->parentNode->replaceChild($node, $parent);
-            }
+        $parents = array();
+        foreach($this as $i => $node) {
+            $parents[] = $node->parentNode;
         }
+
+        self::create($parents)->unwrapInner();
         return $this;
     }
+
+    /**
+     * Remove the matched elements, but promote the children to take their place.
+     *
+     * @return \Wa72\HtmlPageDom\HtmlPageCrawler $this for chaining
+     * @api
+     */
+    public function unwrapInner()
+    {
+        foreach($this as $i => $node) {
+            if (!$node->parentNode instanceof \DOMElement) {
+                throw new InvalidArgumentException('DOMElement does not have a parent DOMElement node.');
+            }
+
+            /** @var DOMNode[] $children */
+            $children = iterator_to_array($node->childNodes);
+            foreach ($children as $child) {
+                $node->parentNode->insertBefore($child, $node);
+            }
+
+            $node->parentNode->removeChild($node);
+        }
+    }
+
 
     /**
      * Wrap an HTML structure around each element in the set of matched elements

--- a/src/HtmlPageCrawler.php
+++ b/src/HtmlPageCrawler.php
@@ -808,7 +808,7 @@ class HtmlPageCrawler extends Crawler
         /** @var \DOMNode $newnode */
         $newnode = static::importNewnode($newnode, $parent);
 
-        $parent->appendChild($newnode);
+        $newnode = $parent->insertBefore($newnode,$this->getNode(0));
         $content->clear();
         $content->add($newnode);
 


### PR DESCRIPTION
Taking the position of the first node being wrapped is what jQuery does.  The old behaviour is to append the wrapped elements to the parent, which is wrong.