### PR TITLE
Prepending self node fix

### DIFF
--- a/Tests/HtmlPageCrawlerTest.php
+++ b/Tests/HtmlPageCrawlerTest.php
@@ -260,6 +260,10 @@ class HtmlPageCrawlerTest extends TestCase
         $c = new HtmlPageCrawler('<div id="content"></div>');
         $c->filter('#content')->prepend(new HtmlPageCrawler('<p>Text before h1</p><p>and more text before</p>'));
         $this->assertEquals('<div id="content"><p>Text before h1</p><p>and more text before</p></div>', $c->saveHTML());
+
+        $c = new HtmlPageCrawler('<div id="content"><span>Prepend Self</span></div>');
+        $c->filter('#content')->prepend($c->filter('span'));
+        $this->assertEquals('<div id="content"><span>Prepend Self</span></div>', $c->saveHTML());
     }
 
     /**

--- a/src/HtmlPageCrawler.php
+++ b/src/HtmlPageCrawler.php
@@ -483,7 +483,7 @@ class HtmlPageCrawler extends Crawler
                 $newnode = static::importNewnode($newnode, $node, $i);
                 if ($refnode === null) {
                     $node->appendChild($newnode);
-                } else {
+                } else if ($refnode !== $newnode) {
                     $node->insertBefore($newnode, $refnode);
                 }
                 $newnodes[] = $newnode;


### PR DESCRIPTION
Found a bug with the prepend code.  If the node being prepended is already at the beginning of the child list of the target node, then the existing code will throw an exception.  In jquery, this is perfectly valid and no change happens to the DOM.   Attached is the bug fix and the unit test for this issue.  I suspect that a few of the other prepend(), after(), and insert() family of functions have the same problem, so these would need to be addressed at some point as well.  I am willing to test and fix those other functions once this pull request is reviewed.