### PR TITLE
Deprecation of mb_convert_encoding with HTML-ENTITIES in PHP 8.2

### DIFF
--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -86,8 +86,11 @@ class Helpers {
                 strtolower($charset),
                 array_map('strtolower', mb_list_encodings())
             )
-        ) {
-            $html = mb_convert_encoding($html, 'HTML-ENTITIES', $charset);
+        ) {          
+            // https://php.watch/versions/8.2/mbstring-qprint-base64-uuencode-html-entities-deprecated#html     
+            $html = mb_convert_encoding($html, 'UTF-8', $charset);
+            $html = htmlentities($html);
+            $html = htmlspecialchars_decode($html);     
         }
         @$d->loadHTML($html);
         libxml_use_internal_errors($current);


### PR DESCRIPTION
See https://php.watch/versions/8.2/mbstring-qprint-base64-uuencode-html-entities-deprecated#html for workaround